### PR TITLE
ui: move prompts from nav to page buttons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,10 +63,6 @@ nav:
       en: "Teams"
     url: "/teams"
   - title:
-      zh: "Prompts"
-      en: "Prompts"
-    url: "/ai-character-prompts"
-  - title:
       zh: "FAQ"
       en: "FAQ"
     url: "/faq"

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -44,6 +44,10 @@ layout: default
         <span class="category-en">{{ item.title.en }}</span>
       </a>
       {% endfor %}
+      <a href="{{ '/ai-character-prompts/' | relative_url }}" class="category-card">
+        <h3>Prompts</h3>
+        <span class="category-en">AI Character Prompts</span>
+      </a>
     </div>
   </div>
 </div>

--- a/_layouts/soul.html
+++ b/_layouts/soul.html
@@ -68,6 +68,7 @@ layout: default
       target="_blank"
       data-i18n="action.edit"
     >修正</a>
+    <a href="{{ '/ai-character-prompts/' | relative_url }}" class="btn btn-prompts">Prompts</a>
   </div>
   
   <div class="soul-content" id="soul-content">

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -46,6 +46,7 @@ layout: default
     <button class="btn btn-download" onclick="downloadTeamConfig()" data-i18n="teams.download_config">
       下载团队配置
     </button>
+    <a href="{{ '/ai-character-prompts/' | relative_url }}" class="btn btn-prompts">Prompts</a>
   </div>
 
   <div class="team-members-section">


### PR DESCRIPTION
- 隐藏导航栏中的 Prompts 链接
- 在首页分类卡片中添加 Prompts 入口
- 在灵魂详情页按钮栏添加 Prompts 按钮
- 在团队页按钮栏添加 Prompts 按钮